### PR TITLE
Increase the alert thresholds

### DIFF
--- a/lua_binding/luasandbox/CMakeLists.txt
+++ b/lua_binding/luasandbox/CMakeLists.txt
@@ -2,5 +2,5 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-project(luasandbox_streaming_algorithms VERSION 0.0.9 LANGUAGES C)
+project(luasandbox_streaming_algorithms VERSION 0.0.10 LANGUAGES C)
 include(lua_binding)

--- a/lua_binding/luasandbox/sandboxes/heka/analysis/heka_message_monitor.lua
+++ b/lua_binding/luasandbox/sandboxes/heka/analysis/heka_message_monitor.lua
@@ -315,7 +315,11 @@ local function output_subtype(key, v, stats)
             v.data:set(v.cint, i, v.p2:estimate(i-1))
         end
         v.counts:set(v.cint, 1, v.p2:count(histogram_buckets - 1))
-        add_to_payload(string.format(',"min":%g,"max":%g', v.p2:estimate(0), v.p2:estimate(histogram_buckets - 1)))
+        local min = v.p2:estimate(0)
+        if min ~= min then min = 0 end
+        local max = v.p2:estimate(histogram_buckets - 1)
+        if max ~= max then max = 0 end
+        add_to_payload(string.format(',"min":%g,"max":%g', min, max))
         local pcc, closest = v.data:pcc(v.cint)
         if pcc then
             add_to_payload(string.format(',"pcc":%g,"closest_row":%d', pcc, closest))


### PR DESCRIPTION
- Wait until enough time has past to collect a full set of samples
- Don't alert if a majority of the samples have not reached the minimum submission level
- Don't alert if at least 25% of the interval is not accounted for